### PR TITLE
Assigned fscanf return value to retval

### DIFF
--- a/src/mir_loop.c
+++ b/src/mir_loop.c
@@ -98,7 +98,7 @@ void mir_omp_loop_desc_init(struct mir_loop_des_t* loop, long start, long end,
         }
         else if (retval != EOF) {
             // Skip over.
-            fscanf(fp, "%*[^\n]");
+            retval = fscanf(fp, "%*[^\n]");
         }
     }
     fclose(fp);


### PR DESCRIPTION
The build system will by default treat warnings as errors, and there was an error building mir_loop.c as there was an fscanf call where the return value was not used. I assigned it to retval, as that seemed to fit in nicely with the program design, and it should not change the behaviour. I also ran all the tests afterwards, and they ran fine.
